### PR TITLE
refactor based on templates

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,16 @@
+name: black
+on:
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+
+jobs:
+  linter_name:
+    name: runner / black formatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rickstaa/action-black@v1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,31 @@
+name: tests
+on:
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on:
+  push:
+    tags:
+      - "*"
+  
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: install build
+        run: python -m pip install --upgrade build
+      - name: build 
+        run: python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # pr-commenter
 
+Create and manage automatic comments in a Github PR
+
 [![tests](https://github.com/Shiphero/pr-commenter/actions/workflows/pytest.yml/badge.svg?branch=main)](https://github.com/Shiphero/pr-commenter/actions/workflows/pytest.yml)
 [![black](https://github.com/Shiphero/pr-commenter/actions/workflows/black.yml/badge.svg?branch=main)](https://github.com/Shiphero/pr-commenter/actions/workflows/black.yml)
 [![PyPI version](https://img.shields.io/pypi/v/pr-commenter)](https://pypi.org/project/pr-commenter/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/pr-commenter)](https://libraries.io/pypi/pr-commenter)
 
 
-A CLI app to manage a comment a Github PR based on content from stdin, files or environment variables.
+`pr-commenter` is CLI app to add a comment a Github PR based on content from stdin, files or environment variables.
 
-You can create a new comment, hide previous one of the same type or update the "current" one.
-
-A hidden metadata is added to the comment so it could be detected in a subsequent run and update or delete if needed.
+You can create a new comment, hide a previous one of the same type or update the "current" one from a different process. This is done with a hidden metadata added to the comment so it could be detected in a subsequent run, and update or hide previous messages if needed.
 
 ## Basic usage
 
@@ -25,6 +25,10 @@ Or from the standard input, using `-` as the file name
 ```
 cat comment.txt | pr-commenter your/repo 12 -
 ```
+
+This will simply create a new comment in the PR 12 with the content of `comment.txt`
+But there is much more. 
+
 
 ## Advanced example
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The first suite that finish will post a comment like this
 
 
 ````markdown
-<!-- pr_commenter: failed_tests.j2 abc123 -->
+<!-- pr-commenter: failed_tests.j2 abc123 -->
 ## Failed tests
  
 [suite client](http://the-client-url):
@@ -73,7 +73,7 @@ edit the comment and append the new content.
 The result will be something like this:
 
 ````markdown
-<!-- pr_commenter: failed_tests.j2 abc123 -->
+<!-- pr-commenter: failed_tests.j2 abc123 -->
 ## Failed tests
  
 [suite client](http://the-client-url):

--- a/README.md
+++ b/README.md
@@ -1,8 +1,108 @@
-# pr_commenter
+# pr-commenter
 
-Comment or update a comment in a given PR
+A CLI app to manage a comment a Github PR based on content from stdin, files or environment variables. 
 
-# Install
+You can create a new comment, delete previous one of the same type
+or update the "current" one. 
+
+An special comment with metadata is added to the comment so it could be 
+detected in a subsequent run and update or delete if needed. 
+
+## Basic usage
+
+Create a Github token with `repo` scope and export it as `PR_COMMENTER_GITHUB_TOKEN` environment variable
+
+```
+pr-commenter your/repo 12 comment.txt
+```
+
+Or from the standard input
+
+```
+cat comment.txt | pr-commenter your/repo 12 -
+```
+
+## Advanced example
+
+Suposse you have a template `failed_tests.j2` like this
+
+```jinja2
+{% if not is_append %}## Failed tests{% endif %}
+ 
+[suite {{ CI_SUITE_NAME }}]({{ CI_SUITE_URL }}):
+
+```bash
+{% for line in input_lines %}{{ line }}
+{% endfor %}
+```
+
+And your suite produce a file `failures.txt`  with the list 
+of failed tests like 
+
+```	
+tests/test_client.py::test_client_simple
+tests/test_client.py::test_client_complex
+```
+
+Suppose you want to add a single comment to the PR with the failed tests for 
+two different suites executions in the same "commit". 
+
+In the post-build phase, you can run
+
+```
+$ pr-commenter your/repo $PR failures.txt -t failed_tests.j2 --build=$COMMIT
+```
+
+The first suite that finish will post a like this
+
+
+````markdown
+<!-- pr_commenter: failed_tests.j2 abc123 -->
+## Failed tests
+ 
+[suite client](http://the-client-url):
+
+```bash
+tests/test_client.py::test_client_simple
+tests/test_client.py::test_client_complex
+```
+````
+
+Then the second suite will find the previous comment for this template 
+and commit (`"abc123"`, so the result will be an update like 
+
+````markdown
+<!-- pr_commenter: failed_tests.j2 abc123 -->
+## Failed tests
+ 
+[suite client](http://the-client-url):
+
+```bash
+tests/test_client.py::test_client_simple
+tests/test_client.py::test_client_complex
+```
+
+[suite server](http://the-server-url):
+
+```bash
+tests/test_server.py::test_server_1
+```
+
+````
+
+In a next commit, the first suite will post a new comment, but this time 
+the commit will be different, so a new comment will be created and the previous
+deleted. 
+
+## Templates
+
+It's use Jinja2 templates. The stdin/files is passed and a variable `input_lines`
+A `is_append` will be `True` in case the new comment will be appended to an existent
+one (so you can ommit some header). In addition, the complete `os.environ`
+dictionary is passed, so all the environment variables are available in the template. 
+
+
+## Install
 
 - Install the package
 
@@ -10,3 +110,8 @@ Comment or update a comment in a given PR
 pip install --user pipx
 pipx install  git+ssh://git@github.com/Shiphero/pr_commenter.git
 ```
+
+- Create a Github token with `repo` scope and export it as `PR_COMMENTER_GITHUB_TOKEN` environment variable
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # pr-commenter
 
+[![tests](https://github.com/Shiphero/pr-commenter/actions/workflows/pytest.yml/badge.svg?branch=main)](https://github.com/Shiphero/pr-commenter/actions/workflows/pytest.yml)
+[![black](https://github.com/Shiphero/pr-commenter/actions/workflows/black.yml/badge.svg?branch=main)](https://github.com/Shiphero/pr-commenter/actions/workflows/black.yml)
+[![PyPI version](https://img.shields.io/pypi/v/pr-commenter)](https://pypi.org/project/pr-commenter/)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/pr-commenter)](https://libraries.io/pypi/pr-commenter)
+
+
 A CLI app to manage a comment a Github PR based on content from stdin, files or environment variables.
 
 You can create a new comment, hide previous one of the same type or update the "current" one.
@@ -105,11 +111,17 @@ In addition, the complete `os.environ` dictionary is passed, so all the environm
 
 ## Install
 
-- Install the package
+- Install the package with pipx
 
 ```
 pip install --user pipx
-pipx install  git+ssh://git@github.com/Shiphero/pr_commenter.git
+pipx install pr-commenter
+```
+
+Alternatively, with pip
+
+```
+pip install --user pr-commenter
 ```
 
 - Create a Github token with `repo` scope and export it as `PR_COMMENTER_GITHUB_TOKEN` environment variable

--- a/pr_commenter.py
+++ b/pr_commenter.py
@@ -32,11 +32,9 @@ logger = logging.getLogger(__file__)
 
 
 def setup_logger(debug=False):
-    # setup logging
-    log_level = logging.DEBUG if debug else logging.INFO
-    logging.basicConfig(
-        level=log_level, format="%(message)s", datefmt="->", handlers=[RichHandler()]
-    )
+    # setup loggin
+    logger.setLevel(logging.DEBUG if debug else logging.INFO)
+    logging.basicConfig(format="%(message)s", datefmt="->", handlers=[RichHandler()])
     
 
 def get_pr_and_user(args):
@@ -112,7 +110,7 @@ def main(argv=None) -> None:
     if not comment:
         comment = render(lines, args["--template"], args["--build"])
 
-        is_empty = re.sub(r"<!-- pr_commenter[^>]*-->", "", comment).strip()
+        is_empty = re.sub(r"<!-- pr_commenter[^>]*-->", "", comment).strip() == ""
         if is_empty:
             logger.info("New comment is empty. Skipping...")
             # remove labels 

--- a/pr_commenter.py
+++ b/pr_commenter.py
@@ -71,7 +71,7 @@ def main(argv=None) -> None:
     args = docopt(__doc__ + usage, argv, version=__version__)
     debug = args["--debug"]
 
-    setup_logger()
+    setup_logger(debug)
 
     pr, user = get_pr_and_user(args)
 
@@ -94,7 +94,8 @@ def main(argv=None) -> None:
             prev_template, previous_build = match.groups()
             if prev_template == args["--template"] and previous_build != args["--build"]:
                 logger.info("Found a previous comment for a different build. Deleting...")
-                previous_comment.delete()
+                if not debug:
+                    previous_comment.delete()
                 break
             elif prev_template == args["--template"] and previous_build == args["--build"]:
                 logger.info("Found a previous comment for the same build. Appending...")

--- a/pr_commenter.py
+++ b/pr_commenter.py
@@ -9,6 +9,7 @@ import requests
 from docopt import DocoptExit, docopt
 from github import Github, GithubException
 from jinja2 import Environment
+
 try:
     from rich.logging import RichHandler
 except ImportError:
@@ -38,7 +39,7 @@ def setup_logger(debug=False):
     # setup loggin
     logger.setLevel(logging.DEBUG if debug else logging.INFO)
     kw = {}
-    if RichHandler: 
+    if RichHandler:
         kw = {"handlers": [RichHandler()]}
     logging.basicConfig(format="%(message)s", datefmt="->", **kw)
 

--- a/pr_commenter.py
+++ b/pr_commenter.py
@@ -88,7 +88,7 @@ def render(lines, template=None, build="", is_append=False):
         t = env.from_string(Path(template).read_text())
         comment = t.render({"input_lines": lines, "is_append": is_append, **environ})
         if not is_append:
-            comment = f"<!-- pr_commenter: {template} {build or ''} -->\n{comment}"
+            comment = f"<!-- pr-commenter: {template} {build or ''} -->\n{comment}"
     else:
         comment = "\n".join(lines)
     logger.debug("Comment:\n%s", comment)
@@ -129,7 +129,7 @@ def main(argv=None) -> None:
 
         first_line = previous_comment.body.split("\n")[0]
 
-        match = re.search(r"<!-- pr_commenter: (\S+) (\S+)?\s*-->", first_line)
+        match = re.search(r"<!-- pr-commenter: (\S+) (\S+)?\s*-->", first_line)
         if match:
             prev_template, prev_build = match.groups()
             if prev_template == template and prev_build != build:
@@ -152,7 +152,7 @@ def main(argv=None) -> None:
     if not comment:
         comment = render(lines, template, args["--build"])
 
-        is_empty = re.sub(r"<!-- pr_commenter[^>]*-->", "", comment).strip() == ""
+        is_empty = re.sub(r"<!-- pr-commenter[^>]*-->", "", comment).strip() == ""
         if is_empty:
             logger.info("New comment is empty. Skipping...")
             for label in labels:

--- a/pr_commenter.py
+++ b/pr_commenter.py
@@ -13,8 +13,8 @@ from rich.logging import RichHandler
 
 usage = """
 Usage:
-  pr_commenter (-h | --help)
-  pr_commenter <repo> <pr> [<file>...] [--template=<template>] [--build=<build>] [--append] [--token=<token>] [--label=<label>...] [--debug]
+  pr-commenter (-h | --help)
+  pr-commenter <repo> <pr> [<file>...] [--template=<template>] [--build=<build>] [--append] [--token=<token>] [--label=<label>...] [--debug]
 
 Options:
   -h --help                     Show this screen.  

--- a/pr_commenter.py
+++ b/pr_commenter.py
@@ -9,7 +9,10 @@ import requests
 from docopt import DocoptExit, docopt
 from github import Github, GithubException
 from jinja2 import Environment
-from rich.logging import RichHandler
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 usage = """
 Usage:
@@ -34,7 +37,10 @@ logger = logging.getLogger(__file__)
 def setup_logger(debug=False):
     # setup loggin
     logger.setLevel(logging.DEBUG if debug else logging.INFO)
-    logging.basicConfig(format="%(message)s", datefmt="->", handlers=[RichHandler()])
+    kw = {}
+    if RichHandler: 
+        kw = {"handlers": [RichHandler()]}
+    logging.basicConfig(format="%(message)s", datefmt="->", **kw)
 
 
 def get_pr_and_user(token, repo, pr_number):

--- a/pr_commenter.py
+++ b/pr_commenter.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import fileinput
 from github import Github, GithubException
 from os import environ
+import requests
 from jinja2 import Environment
 import logging
 from rich.logging import RichHandler
@@ -35,21 +36,50 @@ def setup_logger(debug=False):
     # setup loggin
     logger.setLevel(logging.DEBUG if debug else logging.INFO)
     logging.basicConfig(format="%(message)s", datefmt="->", handlers=[RichHandler()])
-    
 
-def get_pr_and_user(args):
+
+def get_pr_and_user(token, repo, pr_number):
     try:
-        gh = Github(args["--token"] or os.environ["PR_COMMENTER_GITHUB_TOKEN"])
-    except (KeyError, GithubException):
-        logger.fatal("Token not found or is invalid. Pass --token or set envvar PR_COMMENTER_GITHUB_TOKEN")
+        gh = Github(token)
+    except GithubException:
+        logger.fatal("Token is invalid.")
         exit(1)
     try:
         user = gh.get_user().login
-        pr = gh.get_repo(args["<repo>"]).get_pull(int(args["<pr>"].strip("pr/")))
+        pr = gh.get_repo(repo).get_pull(int(pr_number))
         return pr, user
     except (KeyError, GithubException):
         logger.fatal("Repo or PR not found")
         exit(1)
+
+
+def minimize_comment(comment, token, reason="OUTDATED"):
+    """
+    Minimize (hide) a comment on GitHub using the api v4 
+    (as pygithub only cover the api rest v3 and this feature is not there)
+
+    This will hide the comment from view, but not delete it.
+    Valid reasons are: ABUSE, OFF_TOPIC, OUTDATED, RESOLVED, SPAM
+    """
+    minimize_comment = """
+        mutation MinimizeComment($commentId: ID!, $minimizeReason: ReportedContentClassifiers!) {
+            minimizeComment(input: {subjectId: $commentId, classifier: $minimizeReason}) {
+                clientMutationId
+            }
+    }"""
+
+    response = requests.post(
+        "https://api.github.com/graphql",
+        headers={
+            "Authorization": f"token {token}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "query": minimize_comment,
+            "variables": {"commentId": comment.raw_data["node_id"], "minimizeReason": reason},
+        },
+    )
+    logger.info(response.json())
 
 
 def render(lines, template, build="", is_append=False):
@@ -63,21 +93,26 @@ def render(lines, template, build="", is_append=False):
     if is_append:
         return comment
     return f"<!-- pr_commenter: {template} {build or ''} -->\n{comment}"
-    
-    
+
+
 def main(argv=None) -> None:
     args = docopt(__doc__ + usage, argv, version=__version__)
     debug = args["--debug"]
 
     setup_logger(debug)
+    try:
+        token = args["--token"] or environ["PR_COMMENTER_GITHUB_TOKEN"]
+    except KeyError:
+        logger.fatal("Token not found. Pass --token or set the environment variable PR_COMMENTER_GITHUB_TOKEN")
+        exit(1)
 
-    pr, user = get_pr_and_user(args)
+    pr, user = get_pr_and_user(token, repo=args["<repo>"], pr_number=args["<pr>"].strip("pr/"))
 
     lines = []
     with fileinput.input(files=args["<file>"]) as f:
         for line in f:
             lines.append(line.strip())
-    
+
     # update or create a comment
     comment = None
     for previous_comment in pr.get_issue_comments():
@@ -91,15 +126,15 @@ def main(argv=None) -> None:
         if match:
             prev_template, previous_build = match.groups()
             if prev_template == args["--template"] and previous_build != args["--build"]:
-                logger.info("Found a previous comment for a different build. Deleting...")
+                logger.info("Found a previous comment for a different build. Minimizing it...")
                 if not debug:
-                    previous_comment.delete()
+                    minimize_comment(previous_comment, token=token)
                 break
             elif prev_template == args["--template"] and previous_build == args["--build"]:
                 logger.info("Found a previous comment for the same build. Appending...")
                 new_comment = render(lines, args["--template"], args["--build"], is_append=True)
                 comment = f"{previous_comment.body}\n{new_comment}"
-                
+
                 logger.debug(f"Updated comment: {comment}")
                 if not debug:
                     previous_comment.edit(comment)
@@ -113,19 +148,19 @@ def main(argv=None) -> None:
         is_empty = re.sub(r"<!-- pr_commenter[^>]*-->", "", comment).strip() == ""
         if is_empty:
             logger.info("New comment is empty. Skipping...")
-            # remove labels 
+            # remove labels
             for label in args["--label"]:
                 logger.debug(f"Removing label: {label}")
                 pr.remove_from_labels(label)
-        else: 
+        else:
             issue_comment = pr.create_issue_comment(comment)
             logger.debug(f"New comment: {comment}")
             logger.info(f"Comment created: {issue_comment.html_url}")
 
-    if not is_empty and args["--label"]:        
+    if not is_empty and args["--label"]:
         logger.info(f"Labels added: {', '.join(args['--label'])}")
         pr.add_to_labels(*args["--label"])
 
 
-if __name__ == '__main__':
-    main()    
+if __name__ == "__main__":
+    main()

--- a/pr_commenter.py
+++ b/pr_commenter.py
@@ -1,68 +1,130 @@
 """Create or upgrade a comment in a given PR"""
 import os
-import sys
+import re
 from docopt import docopt
+from pathlib import Path
 import fileinput
 from github import Github, GithubException
+from os import environ
+from jinja2 import Environment
+import logging
+from rich.logging import RichHandler
+
 
 usage = """
 Usage:
   pr_commenter (-h | --help)
-  pr_commenter <repo> <pr> <file>... [--title=<title>] [--wrap=<language>] [--token=<token>] [--label=<label>...]
+  pr_commenter <repo> <pr> [<file>...] [--template=<template>] [--build=<build>] [--append] [--token=<token>] [--label=<label>...] [--debug]
 
 Options:
-  -h --help                         Show this screen.  
-  --title=<title>                   Title for the comment
-  --wrap=<language>                 Wrap the comment as code language
-  --token=<token>                   Github token. Default to the envvar PR_COMMENTER_GITHUB_TOKEN.
-  --label=<label>                   Add label/s if there were a comment
+  -h --help                     Show this screen.  
+  -t, --template=<template>     Use a given Jinja template.    
+  --token=<token>               Github token. Default to the envvar PR_COMMENTER_GITHUB_TOKEN.
+  --label=<label>               Add label/s if there were a comment
+  --build=<build>               Identifier. If a comment for the template and build exist the 
+                                new message will be appended.
+  --debug                       Show the final comment but don't post it to Github
 """
 
-__version__ = "0.1"
+__version__ = "0.2"
 
-def main(argv=None) -> None:
-    args = docopt(__doc__ + usage, argv, version=__version__)
+logger = logging.getLogger(__file__)
 
+
+def setup_logger(debug=False):
+    # setup logging
+    log_level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(
+        level=log_level, format="%(message)s", datefmt="->", handlers=[RichHandler()]
+    )
+    
+
+def get_pr_and_user(args):
     try:
         gh = Github(args["--token"] or os.environ["PR_COMMENTER_GITHUB_TOKEN"])
-    except KeyError:
-        raise SystemExit("Token not found. Pass --token or set envvar PR_COMMENTER_GITHUB_TOKEN")
+    except (KeyError, GithubException):
+        logger.fatal("Token not found or is invalid. Pass --token or set envvar PR_COMMENTER_GITHUB_TOKEN")
+        exit(1)
+    try:
+        user = gh.get_user().login
+        pr = gh.get_repo(args["<repo>"]).get_pull(int(args["<pr>"].strip("pr/")))
+        return pr, user
+    except (KeyError, GithubException):
+        logger.fatal("Repo or PR not found")
+        exit(1)
 
 
-    comment = ""
+def render(lines, template, build="", is_append=False):
+    """
+    Render the template passing environment variables and the lines as input_lines
+    """
+    env = Environment(autoescape=True)
+    t = env.from_string(Path(template).read_text())
+    comment = t.render({"input_lines": lines, "is_append": is_append, **environ})
+    logger.debug("Comment:\n%s", comment)
+    if is_append:
+        return comment
+    return f"<!-- pr_commenter: {template} {build or ''} -->\n{comment}"
+    
+    
+def main(argv=None) -> None:
+    args = docopt(__doc__ + usage, argv, version=__version__)
+    debug = args["--debug"]
+
+    setup_logger()
+
+    pr, user = get_pr_and_user(args)
+
+    lines = []
     with fileinput.input(files=args["<file>"]) as f:
         for line in f:
-            comment += line
+            lines.append(line.strip())
     
-    comment = comment.strip()
-    if not comment:
-        print("No comment found. Exiting.")
-        return
-
-    wrap_start = f"```{args['--wrap']}\n" if args['--wrap'] else ""
-    wrap_end = f"\n```" if args['--wrap'] else ""
-    title = f"{args['--title']}" if args["--title"] else "[AUTOMATIC COMMENT]"
-    
-    comment = f"{title}\n\n{wrap_start}{comment}{wrap_end}"
-
-
-    pr = gh.get_repo(args["<repo>"]).get_pull(int(args["<pr>"].strip("pr/")))
-
     # update or create a comment
-    existent_comment = None    
-    for c_issue in pr.get_issue_comments():
-        if c_issue.body.startswith(title):
-            existent_comment = c_issue
-            break
-    if existent_comment:
-        existent_comment.edit(comment)
-        print(f"Comment updated: {existent_comment.html_url}")
-    else:
-        issue_comment = pr.create_issue_comment(comment)
-        print(f"Comment created: {issue_comment.html_url}")
+    comment = None
+    for previous_comment in pr.get_issue_comments():
+        if previous_comment.user.login != user:
+            # only consider comments from the same user
+            continue
 
-    if args["--label"]:        
-        print(f"Labels added: {', '.join(args['--label'])}")
+        first_line = previous_comment.body.split("\n")[0]
+
+        match = re.search(r"<!-- pr_commenter: (\S+) (\S+)?\s*-->", first_line)
+        if match:
+            prev_template, previous_build = match.groups()
+            if prev_template == args["--template"] and previous_build != args["--build"]:
+                logger.info("Found a previous comment for a different build. Deleting...")
+                previous_comment.delete()
+                break
+            elif prev_template == args["--template"] and previous_build == args["--build"]:
+                logger.info("Found a previous comment for the same build. Appending...")
+                new_comment = render(lines, args["--template"], args["--build"], is_append=True)
+                comment = f"{previous_comment.body}\n{new_comment}"
+                
+                logger.debug(f"Updated comment: {comment}")
+                if not debug:
+                    previous_comment.edit(comment)
+                    logger.info(f"Comment updated: {previous_comment.html_url}")
+                break
+
+    is_empty = False
+    if not comment:
+        comment = render(lines, args["--template"], args["--build"])
+
+        is_empty = re.sub(r"<!-- pr_commenter[^>]*-->", "", comment).strip()
+        if is_empty:
+            logger.info("New comment is empty. Skipping...")
+            # remove labels 
+            for label in args["--label"]:
+                logger.debug(f"Removing label: {label}")
+                pr.remove_from_labels(label)
+        else: 
+            issue_comment = pr.create_issue_comment(comment)
+            logger.debug(f"New comment: {comment}")
+            logger.info(f"Comment created: {issue_comment.html_url}")
+
+    if not is_empty and args["--label"]:        
+        logger.info(f"Labels added: {', '.join(args['--label'])}")
         pr.add_to_labels(*args["--label"])
 
 

--- a/pr_commenter.py
+++ b/pr_commenter.py
@@ -1,4 +1,4 @@
-"""Create or upgrade a comment in a given PR"""
+"""Create and manage automatic comments in a Github PR"""
 import fileinput
 import logging
 import re

--- a/pr_commenter.py
+++ b/pr_commenter.py
@@ -1,16 +1,15 @@
 """Create or upgrade a comment in a given PR"""
-import os
-import re
-from docopt import docopt
-from pathlib import Path
 import fileinput
-from github import Github, GithubException
-from os import environ
-import requests
-from jinja2 import Environment
 import logging
-from rich.logging import RichHandler
+import re
+from os import environ
+from pathlib import Path
 
+import requests
+from docopt import DocoptExit, docopt
+from github import Github, GithubException
+from jinja2 import Environment
+from rich.logging import RichHandler
 
 usage = """
 Usage:
@@ -42,20 +41,18 @@ def get_pr_and_user(token, repo, pr_number):
     try:
         gh = Github(token)
     except GithubException:
-        logger.fatal("Token is invalid.")
-        exit(1)
+        raise ValueError("Token is invalid.")
     try:
-        user = gh.get_user().login
+        user = gh.get_user()
         pr = gh.get_repo(repo).get_pull(int(pr_number))
         return pr, user
     except (KeyError, GithubException):
-        logger.fatal("Repo or PR not found")
-        exit(1)
+        raise ValueError("Repo or PR not found")
 
 
 def minimize_comment(comment, token, reason="OUTDATED"):
     """
-    Minimize (hide) a comment on GitHub using the api v4 
+    Minimize (hide) a comment on GitHub using the api v4
     (as pygithub only cover the api rest v3 and this feature is not there)
 
     This will hide the comment from view, but not delete it.
@@ -82,17 +79,20 @@ def minimize_comment(comment, token, reason="OUTDATED"):
     logger.info(response.json())
 
 
-def render(lines, template, build="", is_append=False):
+def render(lines, template=None, build="", is_append=False):
     """
-    Render the template passing environment variables and the lines as input_lines
+    Render the comment template passing environment variables and the lines as input_lines
     """
-    env = Environment(autoescape=True)
-    t = env.from_string(Path(template).read_text())
-    comment = t.render({"input_lines": lines, "is_append": is_append, **environ})
+    if template:
+        env = Environment(autoescape=True)
+        t = env.from_string(Path(template).read_text())
+        comment = t.render({"input_lines": lines, "is_append": is_append, **environ})
+        if not is_append:
+            comment = f"<!-- pr_commenter: {template} {build or ''} -->\n{comment}"
+    else:
+        comment = "\n".join(lines)
     logger.debug("Comment:\n%s", comment)
-    if is_append:
-        return comment
-    return f"<!-- pr_commenter: {template} {build or ''} -->\n{comment}"
+    return comment
 
 
 def main(argv=None) -> None:
@@ -103,20 +103,27 @@ def main(argv=None) -> None:
     try:
         token = args["--token"] or environ["PR_COMMENTER_GITHUB_TOKEN"]
     except KeyError:
-        logger.fatal("Token not found. Pass --token or set the environment variable PR_COMMENTER_GITHUB_TOKEN")
-        exit(1)
+        raise DocoptExit("Token not found. Pass --token or set the environment variable PR_COMMENTER_GITHUB_TOKEN")
 
-    pr, user = get_pr_and_user(token, repo=args["<repo>"], pr_number=args["<pr>"].strip("pr/"))
+    try:
+        pr, user = get_pr_and_user(token, repo=args["<repo>"], pr_number=args["<pr>"].strip("pr/"))
+    except ValueError as e:
+        raise DocoptExit(str(e))
 
+    labels = args["--label"]
+    template = args["--template"]
+    build = args["--build"]
     lines = []
-    with fileinput.input(files=args["<file>"]) as f:
-        for line in f:
-            lines.append(line.strip())
+    files = args["<file>"]
+    if files:
+        with fileinput.input(files=files) as f:
+            for line in f:
+                lines.append(line.strip())
 
     # update or create a comment
     comment = None
     for previous_comment in pr.get_issue_comments():
-        if previous_comment.user.login != user:
+        if previous_comment.user.login != user.login:
             # only consider comments from the same user
             continue
 
@@ -124,15 +131,15 @@ def main(argv=None) -> None:
 
         match = re.search(r"<!-- pr_commenter: (\S+) (\S+)?\s*-->", first_line)
         if match:
-            prev_template, previous_build = match.groups()
-            if prev_template == args["--template"] and previous_build != args["--build"]:
+            prev_template, prev_build = match.groups()
+            if prev_template == template and prev_build != build:
                 logger.info("Found a previous comment for a different build. Minimizing it...")
                 if not debug:
                     minimize_comment(previous_comment, token=token)
                 break
-            elif prev_template == args["--template"] and previous_build == args["--build"]:
+            elif prev_template == template and prev_build == build:
                 logger.info("Found a previous comment for the same build. Appending...")
-                new_comment = render(lines, args["--template"], args["--build"], is_append=True)
+                new_comment = render(lines, template, build, is_append=True)
                 comment = f"{previous_comment.body}\n{new_comment}"
 
                 logger.debug(f"Updated comment: {comment}")
@@ -143,23 +150,23 @@ def main(argv=None) -> None:
 
     is_empty = False
     if not comment:
-        comment = render(lines, args["--template"], args["--build"])
+        comment = render(lines, template, args["--build"])
 
         is_empty = re.sub(r"<!-- pr_commenter[^>]*-->", "", comment).strip() == ""
         if is_empty:
             logger.info("New comment is empty. Skipping...")
-            # remove labels
-            for label in args["--label"]:
-                logger.debug(f"Removing label: {label}")
+            for label in labels:
                 pr.remove_from_labels(label)
+            if labels:
+                logger.info(f"Labels removed: {', '.join(labels)}")
         else:
             issue_comment = pr.create_issue_comment(comment)
             logger.debug(f"New comment: {comment}")
             logger.info(f"Comment created: {issue_comment.html_url}")
 
-    if not is_empty and args["--label"]:
-        logger.info(f"Labels added: {', '.join(args['--label'])}")
-        pr.add_to_labels(*args["--label"])
+    if not is_empty and labels:
+        logger.info(f"Labels added: {', '.join(labels)}")
+        pr.add_to_labels(*labels)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ Changelog = "https://github.com/Shiphero/pr-commenter/blob/main/CHANGELOG.md"
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "black"
+    "black",
+    "rich"
 ]
 
 [tool.ipdb]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ Changelog = "https://github.com/Shiphero/pr-commenter/blob/main/CHANGELOG.md"
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-mock",
     "black",
     "rich"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,11 @@ dev = [
 [tool.ipdb]
 context=5
 
-
 [tool.black]
 line-length = 120
 target-version = ["py37"]
 color = true
+
+[tool.ruff]
+target-version = "py37"
+line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "pr_commenter"
+name = "pr-commenter"
 readme = "README.md"
 requires-python = ">=3.7"
 license = {text = "BSD 3-Clause License"}
@@ -16,11 +16,12 @@ authors = [
 dependencies = [
     "pygithub >= 1.55",
     "docopt-ng >= 0.8.1",
+    "Jinja2 >= 3",
 ]
 dynamic = ["version", "description"]
 
 [project.scripts]
-pr_commenter = "pr_commenter:main"
+pr-commenter = "pr_commenter:main"
 
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,12 @@ requires-python = ">=3.7"
 license = {text = "BSD 3-Clause License"}
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Development Status :: 4 - Beta",
+    "Environment :: Console", 
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Communications",
+    "Topic :: Software Development :: Build Tools",
 ]
 authors = [
     {name = "Martín Gaitán", email = "marting@shiphero.com"}
@@ -22,6 +28,10 @@ dynamic = ["version", "description"]
 
 [project.scripts]
 pr-commenter = "pr_commenter:main"
+
+[project.urls]
+Home = "https://github.com/Shiphero/pr-commenter"
+Changelog = "https://github.com/Shiphero/pr-commenter/blob/main/CHANGELOG.md"
 
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,15 @@ import pytest
 
 
 @pytest.fixture
+def template_simple(tmp_path):
+    template = tmp_path / 'simple.j2'
+    template.write_text("""
+      Content: {{ CONTENT }}
+    """)
+    return str(template)
+
+
+@pytest.fixture
 def template(tmp_path):
     template = tmp_path / 'test_template.j2'
     template.write_text("""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,17 +3,20 @@ import pytest
 
 @pytest.fixture
 def template_simple(tmp_path):
-    template = tmp_path / 'simple.j2'
-    template.write_text("""
+    template = tmp_path / "simple.j2"
+    template.write_text(
+        """
       Content: {{ CONTENT }}
-    """)
+    """
+    )
     return str(template)
 
 
 @pytest.fixture
 def template(tmp_path):
-    template = tmp_path / 'test_template.j2'
-    template.write_text("""
+    template = tmp_path / "test_template.j2"
+    template.write_text(
+        """
     {% if not is_append %}# Example{% endif %}
     {{ TITLE }}
 
@@ -21,5 +24,6 @@ def template(tmp_path):
     {% for line in input_lines %}{{ line }}
     {% endfor %}
     ```
-    """)
+    """
+    )
     return str(template)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.fixture
+def template(tmp_path):
+    template = tmp_path / 'test_template.j2'
+    template.write_text("""
+    {% if not is_append %}# Example{% endif %}
+    {{ TITLE }}
+
+    ```bash
+    {% for line in input_lines %}{{ line }}
+    {% endfor %}
+    ```
+    """)
+    return str(template)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,7 +63,9 @@ def test_existent_comment_same_build(monkeypatch, template_simple, mocker, pr_an
     minimize.assert_not_called()
     pr.create_issue_comment.assert_not_called()
 
-    expected = f"<!-- pr_commenter: {template_simple} abc1 -->\n    Content: original\n\n      Content: new content\n    "
+    expected = (
+        f"<!-- pr_commenter: {template_simple} abc1 -->\n    Content: original\n\n      Content: new content\n    "
+    )
     previous_comment.edit.assert_called_once_with(expected)
 
     assert caplog.messages[0] == "Found a previous comment for the same build. Appending..."
@@ -87,16 +89,16 @@ def test_with_existent_comment_other_build(monkeypatch, token, template_simple, 
     pr.get_issue_comments.configure_mock(return_value=[previous_comment])
     new_comment = mocker.MagicMock(name="new_comment", autospec=PullRequestComment, html_url="new_comment_url")
     pr.create_issue_comment.configure_mock(return_value=new_comment)
-    
+
     main(argv=["user/repo", "1", "--build", "xyz2", "--template", template_simple])
 
     # original was minimized
     minimize.assert_called_once_with(previous_comment, token="token1")
-    
+
     previous_comment.edit.assert_not_called()
 
     expected = f"<!-- pr_commenter: {template_simple} xyz2 -->\n\n      Content: new content\n    "
-    
+
     pr.create_issue_comment.assert_called_once_with(expected)
 
     assert caplog.messages[0] == "Found a previous comment for a different build. Minimizing it..."
@@ -115,11 +117,9 @@ def test_empty_remove_labels(mocker, pr_and_user, caplog):
     mocker.patch("pr_commenter.render", return_value="<!-- pr_commenter: foo xyz2 -->\n")
     pr = pr_and_user[0]
     main(argv=["user/repo", "1", "--label", "foo", "--label", "bar"])
-    pr.remove_from_labels.assert_has_calls([
-        mocker.call("foo"),
-        mocker.call("bar")
-    ])
+    pr.remove_from_labels.assert_has_calls([mocker.call("foo"), mocker.call("bar")])
     assert caplog.messages[1] == "Labels removed: foo, bar"
+
 
 def test_not_empty_add_labels(mocker, pr_and_user, caplog):
     mocker.patch("pr_commenter.render", return_value="<!-- pr_commenter: foo xyz2 -->\ncomment")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,7 @@ def test_existent_comment_same_build(monkeypatch, template_simple, mocker, pr_an
         autospec=PullRequestComment,
         user=user,
         html_url="url_comment1",
-        body=f"<!-- pr_commenter: {template_simple} abc1 -->\n    Content: original",
+        body=f"<!-- pr-commenter: {template_simple} abc1 -->\n    Content: original",
     )
     pr.get_issue_comments.configure_mock(return_value=[previous_comment])
 
@@ -64,7 +64,7 @@ def test_existent_comment_same_build(monkeypatch, template_simple, mocker, pr_an
     pr.create_issue_comment.assert_not_called()
 
     expected = (
-        f"<!-- pr_commenter: {template_simple} abc1 -->\n    Content: original\n\n      Content: new content\n    "
+        f"<!-- pr-commenter: {template_simple} abc1 -->\n    Content: original\n\n      Content: new content\n    "
     )
     previous_comment.edit.assert_called_once_with(expected)
 
@@ -84,7 +84,7 @@ def test_with_existent_comment_other_build(monkeypatch, token, template_simple, 
         autospec=PullRequestComment,
         user=user,
         html_url="comment1",
-        body=f"<!-- pr_commenter: {template_simple} abc1 -->\n    Content: original",
+        body=f"<!-- pr-commenter: {template_simple} abc1 -->\n    Content: original",
     )
     pr.get_issue_comments.configure_mock(return_value=[previous_comment])
     new_comment = mocker.MagicMock(name="new_comment", autospec=PullRequestComment, html_url="new_comment_url")
@@ -97,7 +97,7 @@ def test_with_existent_comment_other_build(monkeypatch, token, template_simple, 
 
     previous_comment.edit.assert_not_called()
 
-    expected = f"<!-- pr_commenter: {template_simple} xyz2 -->\n\n      Content: new content\n    "
+    expected = f"<!-- pr-commenter: {template_simple} xyz2 -->\n\n      Content: new content\n    "
 
     pr.create_issue_comment.assert_called_once_with(expected)
 
@@ -106,7 +106,7 @@ def test_with_existent_comment_other_build(monkeypatch, token, template_simple, 
 
 
 def test_empty_new_comment(mocker, pr_and_user, caplog):
-    mocker.patch("pr_commenter.render", return_value="<!-- pr_commenter: foo xyz2 -->\n")
+    mocker.patch("pr_commenter.render", return_value="<!-- pr-commenter: foo xyz2 -->\n")
     pr = pr_and_user[0]
     main(argv=["user/repo", "1"])
     pr.create_issue_comment.assert_not_called()
@@ -114,7 +114,7 @@ def test_empty_new_comment(mocker, pr_and_user, caplog):
 
 
 def test_empty_remove_labels(mocker, pr_and_user, caplog):
-    mocker.patch("pr_commenter.render", return_value="<!-- pr_commenter: foo xyz2 -->\n")
+    mocker.patch("pr_commenter.render", return_value="<!-- pr-commenter: foo xyz2 -->\n")
     pr = pr_and_user[0]
     main(argv=["user/repo", "1", "--label", "foo", "--label", "bar"])
     pr.remove_from_labels.assert_has_calls([mocker.call("foo"), mocker.call("bar")])
@@ -122,7 +122,7 @@ def test_empty_remove_labels(mocker, pr_and_user, caplog):
 
 
 def test_not_empty_add_labels(mocker, pr_and_user, caplog):
-    mocker.patch("pr_commenter.render", return_value="<!-- pr_commenter: foo xyz2 -->\ncomment")
+    mocker.patch("pr_commenter.render", return_value="<!-- pr-commenter: foo xyz2 -->\ncomment")
     pr = pr_and_user[0]
     main(argv=["user/repo", "1", "--label", "foo", "--label", "bar"])
     pr.remove_from_labels.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ def pr_and_user(mocker):
     return ret
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def token(monkeypatch):
     monkeypatch.setenv("PR_COMMENTER_GITHUB_TOKEN", "token1")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,10 +7,10 @@ from github import PullRequest, AuthenticatedUser, PullRequestComment
 
 @pytest.fixture
 def pr_and_user(mocker):
-    pull_request_mock = mocker.MagicMock(name='pull_request', autospec=PullRequest)
-    user_mock = mocker.MagicMock(name='user', autospec=AuthenticatedUser, login='test_user')
+    pull_request_mock = mocker.MagicMock(name="pull_request", autospec=PullRequest)
+    user_mock = mocker.MagicMock(name="user", autospec=AuthenticatedUser, login="test_user")
     ret = (pull_request_mock, user_mock)
-    mocker.patch('pr_commenter.get_pr_and_user', return_value=ret)
+    mocker.patch("pr_commenter.get_pr_and_user", return_value=ret)
     return ret
 
 
@@ -21,10 +21,110 @@ def token(monkeypatch):
 
 def test_basic_from_file(tmp_path, mocker, pr_and_user, caplog):
     pr, user = pr_and_user
-    comment = mocker.MagicMock(name='comment', autospec=PullRequestComment, html_url='url1')
+    comment = mocker.MagicMock(name="comment", autospec=PullRequestComment, html_url="url1")
     pr.create_issue_comment.configure_mock(return_value=comment)
-    content = tmp_path / 'content.txt'
+    content = tmp_path / "content.txt"
     content.write_text("l1\nl2\n"),
     main(argv=["user/repo", "1", str(content)])
     pr.create_issue_comment.assert_called_once_with("l1\nl2")
     assert caplog.messages[0] == "Comment created: url1"
+
+
+def test_basic_from_multi_file(tmp_path, mocker, pr_and_user, caplog):
+    pr, user = pr_and_user
+    comment = mocker.MagicMock(name="comment", autospec=PullRequestComment, html_url="url1")
+    pr.create_issue_comment.configure_mock(return_value=comment)
+    content = tmp_path / "content.txt"
+    content2 = tmp_path / "content2.txt"
+    content.write_text("l1\nl2\n"),
+    content2.write_text("l3\nl4\n"),
+    main(argv=["user/repo", "1", str(content), str(content2)])
+    pr.create_issue_comment.assert_called_once_with("l1\nl2\nl3\nl4")
+
+
+def test_existent_comment_same_build(monkeypatch, template_simple, mocker, pr_and_user, caplog):
+    minimize = mocker.patch("pr_commenter.minimize_comment")
+    pr, user = pr_and_user
+
+    monkeypatch.setenv("CONTENT", "new content")
+
+    # create a previous comment
+    previous_comment = mocker.MagicMock(
+        name="comment",
+        autospec=PullRequestComment,
+        user=user,
+        html_url="url_comment1",
+        body=f"<!-- pr_commenter: {template_simple} abc1 -->\n    Content: original",
+    )
+    pr.get_issue_comments.configure_mock(return_value=[previous_comment])
+
+    main(argv=["user/repo", "1", "--build", "abc1", "--template", template_simple])
+
+    minimize.assert_not_called()
+    pr.create_issue_comment.assert_not_called()
+
+    expected = f"<!-- pr_commenter: {template_simple} abc1 -->\n    Content: original\n\n      Content: new content\n    "
+    previous_comment.edit.assert_called_once_with(expected)
+
+    assert caplog.messages[0] == "Found a previous comment for the same build. Appending..."
+    assert caplog.messages[1] == "Comment updated: url_comment1"
+
+
+def test_with_existent_comment_other_build(monkeypatch, token, template_simple, mocker, pr_and_user, caplog):
+    minimize = mocker.patch("pr_commenter.minimize_comment")
+    pr, user = pr_and_user
+
+    monkeypatch.setenv("CONTENT", "new content")
+
+    # create a previous comment
+    previous_comment = mocker.MagicMock(
+        name="comment",
+        autospec=PullRequestComment,
+        user=user,
+        html_url="comment1",
+        body=f"<!-- pr_commenter: {template_simple} abc1 -->\n    Content: original",
+    )
+    pr.get_issue_comments.configure_mock(return_value=[previous_comment])
+    new_comment = mocker.MagicMock(name="new_comment", autospec=PullRequestComment, html_url="new_comment_url")
+    pr.create_issue_comment.configure_mock(return_value=new_comment)
+    
+    main(argv=["user/repo", "1", "--build", "xyz2", "--template", template_simple])
+
+    # original was minimized
+    minimize.assert_called_once_with(previous_comment, token="token1")
+    
+    previous_comment.edit.assert_not_called()
+
+    expected = f"<!-- pr_commenter: {template_simple} xyz2 -->\n\n      Content: new content\n    "
+    
+    pr.create_issue_comment.assert_called_once_with(expected)
+
+    assert caplog.messages[0] == "Found a previous comment for a different build. Minimizing it..."
+    assert caplog.messages[1] == "Comment created: new_comment_url"
+
+
+def test_empty_new_comment(mocker, pr_and_user, caplog):
+    mocker.patch("pr_commenter.render", return_value="<!-- pr_commenter: foo xyz2 -->\n")
+    pr = pr_and_user[0]
+    main(argv=["user/repo", "1"])
+    pr.create_issue_comment.assert_not_called()
+    assert caplog.messages[0] == "New comment is empty. Skipping..."
+
+
+def test_empty_remove_labels(mocker, pr_and_user, caplog):
+    mocker.patch("pr_commenter.render", return_value="<!-- pr_commenter: foo xyz2 -->\n")
+    pr = pr_and_user[0]
+    main(argv=["user/repo", "1", "--label", "foo", "--label", "bar"])
+    pr.remove_from_labels.assert_has_calls([
+        mocker.call("foo"),
+        mocker.call("bar")
+    ])
+    assert caplog.messages[1] == "Labels removed: foo, bar"
+
+def test_not_empty_add_labels(mocker, pr_and_user, caplog):
+    mocker.patch("pr_commenter.render", return_value="<!-- pr_commenter: foo xyz2 -->\ncomment")
+    pr = pr_and_user[0]
+    main(argv=["user/repo", "1", "--label", "foo", "--label", "bar"])
+    pr.remove_from_labels.assert_not_called()
+    pr.add_to_labels.assert_called_once_with("foo", "bar")
+    assert caplog.messages[1] == "Labels added: foo, bar"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,30 @@
+import pytest
+
+from pr_commenter import main
+
+from github import PullRequest, AuthenticatedUser, PullRequestComment
+
+
+@pytest.fixture
+def pr_and_user(mocker):
+    pull_request_mock = mocker.MagicMock(name='pull_request', autospec=PullRequest)
+    user_mock = mocker.MagicMock(name='user', autospec=AuthenticatedUser, login='test_user')
+    ret = (pull_request_mock, user_mock)
+    mocker.patch('pr_commenter.get_pr_and_user', return_value=ret)
+    return ret
+
+
+@pytest.fixture
+def token(monkeypatch):
+    monkeypatch.setenv("PR_COMMENTER_GITHUB_TOKEN", "token1")
+
+
+def test_basic_from_file(tmp_path, mocker, pr_and_user, caplog):
+    pr, user = pr_and_user
+    comment = mocker.MagicMock(name='comment', autospec=PullRequestComment, html_url='url1')
+    pr.create_issue_comment.configure_mock(return_value=comment)
+    content = tmp_path / 'content.txt'
+    content.write_text("l1\nl2\n"),
+    main(argv=["user/repo", "1", str(content)])
+    pr.create_issue_comment.assert_called_once_with("l1\nl2")
+    assert caplog.messages[0] == "Comment created: url1"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,7 +10,7 @@ def test_render(template, monkeypatch):
     monkeypatch.setenv("TITLE", "the title")
     result = render(["l1", "l2"], template, build="abc1")
     first_line, rest = result.split("\n", 1)
-    assert first_line == f"<!-- pr_commenter: {template} abc1 -->"
+    assert first_line == f"<!-- pr-commenter: {template} abc1 -->"
     assert (
         rest
         == """

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,7 +11,9 @@ def test_render(template, monkeypatch):
     result = render(["l1", "l2"], template, build="abc1")
     first_line, rest = result.split("\n", 1)
     assert first_line == f"<!-- pr_commenter: {template} abc1 -->"
-    assert rest == """
+    assert (
+        rest
+        == """
     # Example
     the title
 
@@ -21,11 +23,15 @@ def test_render(template, monkeypatch):
     
     ```
     """
+    )
+
 
 def test_render_append(template, monkeypatch):
     monkeypatch.setenv("TITLE", "the title")
     result = render(["l1", "l2"], template, build="abc1", is_append=True)
-    assert result == """
+    assert (
+        result
+        == """
     
     the title
 
@@ -35,3 +41,4 @@ def test_render_append(template, monkeypatch):
     
     ```
     """
+    )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,9 @@
-from textwrap import dedent
 from pr_commenter import render
+
+
+def test_render_no_template():
+    result = render(["l1", "l2"])
+    assert result == "l1\nl2"
 
 
 def test_render(template, monkeypatch):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,33 @@
+from textwrap import dedent
+from pr_commenter import render
+
+
+def test_render(template, monkeypatch):
+    monkeypatch.setenv("TITLE", "the title")
+    result = render(["l1", "l2"], template, build="abc1")
+    first_line, rest = result.split("\n", 1)
+    assert first_line == f"<!-- pr_commenter: {template} abc1 -->"
+    assert rest == """
+    # Example
+    the title
+
+    ```bash
+    l1
+    l2
+    
+    ```
+    """
+
+def test_render_append(template, monkeypatch):
+    monkeypatch.setenv("TITLE", "the title")
+    result = render(["l1", "l2"], template, build="abc1", is_append=True)
+    assert result == """
+    
+    the title
+
+    ```bash
+    l1
+    l2
+    
+    ```
+    """


### PR DESCRIPTION
a full refactor.  Instead arguments like `--title` or `--wrap` that were used to format the comment (a basic implicit template) now we use a real jinja2 template that receive not only files or stdin but also the environment variables. 

Also, it doesn't rely on the "title" to find previous comments to be updated, but in a mark that is " template + id"  . 

If the template is found but with a diff id, that one will be deleted an a new message will be posted,.  If "template" is found but with the same id, then the message will be updated, maybe skipping part of the rendered comment (the part on `{% if not is_append ... }` ) 

this will allows to have just one comment per push, populated from different suites. 
When a new push trigger all the the new builds, then the previous comment will be deleted an a new one posted. 

Also added tests, CI, changelog, etc. 





