### PR TITLE
Change supported python version list

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Issue

> The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
https://github.com/Shiphero/pr-commenter/actions/runs/13590569249/job/37995420902?pr=6#step:3:10

### Solution
Change supported python version list